### PR TITLE
Feat/#27 - StoreServiceImpl 구현 (2/2)

### DIFF
--- a/src/main/kotlin/com/sowez/photo/entity/Store.kt
+++ b/src/main/kotlin/com/sowez/photo/entity/Store.kt
@@ -56,6 +56,9 @@ class Store(
     var boothInfo: BoothInfo? = boothInfo
         protected set
 
+    @OneToMany(mappedBy = "store")
+    private var reviews: MutableList<Review> = mutableListOf()
+
     fun addBoothInfo(boothInfo: BoothInfo?) {
         this.boothInfo = boothInfo
     }
@@ -67,6 +70,10 @@ class Store(
         return payTypeStrings.map {
             PayType.valueOf(it)
         }.toSet()
+    }
+
+    fun getReviewCount(): Int {
+        return reviews.count()
     }
 
     fun editName(name: String) {

--- a/src/main/kotlin/com/sowez/photo/repository/ImageRepository.kt
+++ b/src/main/kotlin/com/sowez/photo/repository/ImageRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface ImageRepository: JpaRepository<Image, Long> {
+    fun findAllByIdInOrderByIdDesc(ids: List<Long>): List<Image>
 }

--- a/src/main/kotlin/com/sowez/photo/repository/ReviewImageRepository.kt
+++ b/src/main/kotlin/com/sowez/photo/repository/ReviewImageRepository.kt
@@ -1,9 +1,25 @@
 package com.sowez.photo.repository
 
+import com.sowez.photo.entity.Image
+import com.sowez.photo.entity.Review
 import com.sowez.photo.entity.ReviewImage
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface ReviewImageRepository: JpaRepository<ReviewImage, Long> {
+
+    @Query(value = "select ri.image.id " +
+            "from ReviewImage ri join ri.review r " +
+            "where r.store.id = :storeId and ri.image.id < :lastId " +
+            "order by ri.id desc")
+    fun findNextImageIds(storeId: Long, lastId: Int, pageable: Pageable): List<Long>
+
+    @Query(value = "select ri.image.id " +
+            "from ReviewImage ri join ri.review r " +
+            "where r.store.id = :storeId " +
+            "order by ri.id desc")
+    fun findNewestImageIds(storeId: Long, pageable: Pageable): List<Long>
 }

--- a/src/main/kotlin/com/sowez/photo/repository/StoreRepository.kt
+++ b/src/main/kotlin/com/sowez/photo/repository/StoreRepository.kt
@@ -1,9 +1,12 @@
 package com.sowez.photo.repository
 
 import com.sowez.photo.entity.Store
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface StoreRepository: JpaRepository<Store, Long> {
+    fun findByNameContaining(name: String, pageable: Pageable): Page<Store>
 }

--- a/src/main/kotlin/com/sowez/photo/service/StoreService.kt
+++ b/src/main/kotlin/com/sowez/photo/service/StoreService.kt
@@ -109,11 +109,15 @@ class StoreServiceImpl(
     }
 
     override fun searchStore(query: String, pageable: Pageable): Page<StoreSearchResDto> {
-        println("StoreServiceTestImpl.searchStore")
-        return PageImpl(listOf(
-                StoreSearchResDto(storeId = 1L, storeName = "하루필름 강남점", storeAddress = "여기저기", reviewCnt = 101),
-                StoreSearchResDto(storeId = 4L, storeName = "하루필름 강남2호점", storeAddress = "요기조기", reviewCnt = 79),
-        ), PageRequest.of(1, 10), 2)
+        return storeRepository.findByNameContaining(query, pageable)
+            .map { store ->
+                StoreSearchResDto(
+                    storeId = store.id,
+                    storeName = store.name,
+                    storeAddress = store.addressInfo.address,
+                    reviewCnt = store.getReviewCount()
+                )
+            }
     }
 
     override fun getBrandLogoImage(storeId: Long): StoreBrandLogoImageResDto {

--- a/src/main/kotlin/com/sowez/photo/service/StoreService.kt
+++ b/src/main/kotlin/com/sowez/photo/service/StoreService.kt
@@ -8,10 +8,8 @@ import com.sowez.photo.entity.Image
 import com.sowez.photo.entity.Store
 import com.sowez.photo.error.BrandNotFoundException
 import com.sowez.photo.error.StoreNotFoundException
-import com.sowez.photo.repository.BrandRepository
-import com.sowez.photo.repository.StoreRepository
+import com.sowez.photo.repository.*
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -32,7 +30,10 @@ interface StoreService {
 @Transactional(readOnly = true)
 class StoreServiceImpl(
     val storeRepository: StoreRepository,
-    val brandRepository: BrandRepository
+    val brandRepository: BrandRepository,
+    val reviewRepository: ReviewRepository,
+    val reviewImageRepository: ReviewImageRepository,
+    val imageRepository: ImageRepository
 ): StoreService {
 
     @Transactional
@@ -134,15 +135,17 @@ class StoreServiceImpl(
     }
 
     override fun getStoreImages(storeId: Long, limit: Int, offset: Int?): StoreImagesResDto {
-        println("StoreServiceTestImpl.getStoreImages(storeId=$storeId, limit=$limit, offset=$offset)")
-        return StoreImagesResDto(
-                images = listOf(
-                        StoreImageResDto(imageId = 1L, imageUrl = "https://www.forefilm.com/images/1234"),
-                        StoreImageResDto(imageId = 5L, imageUrl = "https://www.forefilm.com/images/4321"),
-                        StoreImageResDto(imageId = 10L, imageUrl = "https://www.forefilm.com/images/43")
-                ),
-                lastImageId = 10L
-        )
+        val imageIds = if (offset != null){
+            reviewImageRepository.findNextImageIds(storeId, offset, PageRequest.of(0, limit))
+        } else {
+            reviewImageRepository.findNewestImageIds(storeId, PageRequest.of(0, limit))
+        }
+
+        val imageResDtos = imageRepository.findAllByIdInOrderByIdDesc(imageIds)
+            .map { image -> StoreImageResDto(imageId = image.id, imageUrl = getImageUrl(image)) }
+        val lastId = if(imageResDtos.isNotEmpty()) imageResDtos.last().imageId else null
+
+        return StoreImagesResDto(imageResDtos, lastId)
     }
 
     private fun getImageUrl(image: Image): String {

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,15 @@
+server:
+  port: 4000
+
+spring:
+  datasource:
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true

--- a/src/test/kotlin/com/sowez/photo/controller/StoreControllerTest.kt
+++ b/src/test/kotlin/com/sowez/photo/controller/StoreControllerTest.kt
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.sowez.photo.dto.req.StoreCreateReqDto
 import com.sowez.photo.dto.req.StoreEditReqDto
 import com.sowez.photo.entity.*
-import com.sowez.photo.repository.BrandRepository
-import com.sowez.photo.repository.ImageRepository
-import com.sowez.photo.repository.ReviewRepository
-import com.sowez.photo.repository.StoreRepository
+import com.sowez.photo.repository.*
 import com.sowez.photo.type.PayType
 import com.sowez.photo.type.StoreType
 import org.junit.jupiter.api.Assertions
@@ -35,7 +32,8 @@ class StoreControllerTest(
     @Autowired val storeRepository: StoreRepository,
     @Autowired val brandRepository: BrandRepository,
     @Autowired val imageRepository: ImageRepository,
-    @Autowired val reviewRepository: ReviewRepository
+    @Autowired val reviewRepository: ReviewRepository,
+    @Autowired val reviewImageRepository: ReviewImageRepository
 ) {
 
     @Test
@@ -412,36 +410,133 @@ class StoreControllerTest(
     @Test
     @DisplayName("매장 사진 리스트 조회")
     fun get_store_images() {
-        // when & then
-        mockMvc.perform(
-            get("/stores/{storeId}/images?limit=20&offset=1", 1L)
+        // given
+        val image = imageRepository.save(
+            Image(
+                uuid = UUID.randomUUID().toString(),
+                originalName = "image.jpg",
+                name = "image",
+                extension = "jpg",
+                path = "/image"
+            )
         )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.body.images[0].image_id").value(1L))
-            .andExpect(jsonPath("$.body.images[0].image_url").value("https://www.forefilm.com/images/1234"))
-            .andExpect(jsonPath("$.body.images[1].image_id").value(5L))
-            .andExpect(jsonPath("$.body.images[1].image_url").value("https://www.forefilm.com/images/4321"))
-            .andExpect(jsonPath("$.body.images[2].image_id").value(10L))
-            .andExpect(jsonPath("$.body.images[2].image_url").value("https://www.forefilm.com/images/43"))
-            .andExpect(jsonPath("$.body.last_image_id").value(10L))
-            .andDo(print())
-    }
 
-    @Test
-    @DisplayName("매장 사진 리스트 조회 (limit, offset 정보 없음)")
-    fun get_store_images_no_param() {
-        // when & then
+        val brand = brandRepository.save(
+            Brand(
+                logoImage = image,
+                name = "하루필름"
+            )
+        )
+
+        val store = storeRepository.save(
+            Store(
+                name = "하루필름 강남점",
+                type = StoreType.STORE,
+                addressInfo = Address(address = "여기저기"),
+                brand = brand,
+                operatingTime = "24시간 영업",
+                phoneNumber = "014-1234-5678",
+                payTypes = listOf(PayType.CARD, PayType.CASH)
+            )
+        )
+
+        val reviewImages = mutableListOf<Image>()
+        for (i in 0..9) {
+            reviewImages.add(
+                imageRepository.save(
+                    Image(
+                        uuid = UUID.randomUUID().toString(),
+                        originalName = "image$i.jpg",
+                        name = "image$i",
+                        extension = "jpg",
+                        path = "/image$i"
+                    )
+                )
+            )
+        }
+
+        val review1 = reviewRepository.save(
+            Review(
+                store = store,
+                contents = "내용",
+                nickname = "계정",
+                password = "1234",
+                isDeleted = false
+            )
+        )
+        val review2 = reviewRepository.save(
+            Review(
+                store = store,
+                contents = "내용",
+                nickname = "계정",
+                password = "1234",
+                isDeleted = false
+            )
+        )
+        val review3 = reviewRepository.save(
+            Review(
+                store = store,
+                contents = "내용",
+                nickname = "계정",
+                password = "1234",
+                isDeleted = false
+            )
+        )
+
+
+        for (reviewImage in reviewImages.subList(0, 3)) {
+            reviewImageRepository.save(ReviewImage(review1, reviewImage))
+        }
+
+        for (reviewImage in reviewImages.subList(3, 8)) {
+            reviewImageRepository.save(ReviewImage(review2, reviewImage))
+        }
+
+        for (reviewImage in reviewImages.subList(8, 10)) {
+            reviewImageRepository.save(ReviewImage(review3, reviewImage))
+        }
+
+
+        // when & then - limit만 주어진 경우 (최신 사진 limit개 조회)
+        val limit = 3
         mockMvc.perform(
-            get("/stores/{storeId}/images", 1L)
+            get("/stores/{storeId}/images?limit={limit}", store.id, limit)
         )
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.body.images[0].image_id").value(1L))
-            .andExpect(jsonPath("$.body.images[0].image_url").value("https://www.forefilm.com/images/1234"))
-            .andExpect(jsonPath("$.body.images[1].image_id").value(5L))
-            .andExpect(jsonPath("$.body.images[1].image_url").value("https://www.forefilm.com/images/4321"))
-            .andExpect(jsonPath("$.body.images[2].image_id").value(10L))
-            .andExpect(jsonPath("$.body.images[2].image_url").value("https://www.forefilm.com/images/43"))
-            .andExpect(jsonPath("$.body.last_image_id").value(10L))
+            .andExpect(jsonPath("$.body.images.size()").value(limit))
+            .andExpect(jsonPath("$.body.images[0].image_id").value(reviewImages[9].id))
+            .andExpect(jsonPath("$.body.images[0].image_url").value("https://www.forefilm.com/image9"))
+            .andExpect(jsonPath("$.body.images[1].image_id").value(reviewImages[8].id))
+            .andExpect(jsonPath("$.body.images[1].image_url").value("https://www.forefilm.com/image8"))
+            .andExpect(jsonPath("$.body.images[2].image_id").value(reviewImages[7].id))
+            .andExpect(jsonPath("$.body.images[2].image_url").value("https://www.forefilm.com/image7"))
+            .andExpect(jsonPath("$.body.last_image_id").value(reviewImages[7].id))
+            .andDo(print())
+
+        // when & then - limit, offset 둘다 주어진 경우
+        var offset = reviewImages[7].id
+        mockMvc.perform(
+            get("/stores/{storeId}/images?limit={limit}&offset={offset}", store.id, limit, offset)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.body.images.size()").value(limit))
+            .andExpect(jsonPath("$.body.images[0].image_id").value(reviewImages[6].id))
+            .andExpect(jsonPath("$.body.images[0].image_url").value("https://www.forefilm.com/image6"))
+            .andExpect(jsonPath("$.body.images[1].image_id").value(reviewImages[5].id))
+            .andExpect(jsonPath("$.body.images[1].image_url").value("https://www.forefilm.com/image5"))
+            .andExpect(jsonPath("$.body.images[2].image_id").value(reviewImages[4].id))
+            .andExpect(jsonPath("$.body.images[2].image_url").value("https://www.forefilm.com/image4"))
+            .andExpect(jsonPath("$.body.last_image_id").value(reviewImages[4].id))
+            .andDo(print())
+
+        // when & then - 사진이 더이상 없는 경우
+        offset = reviewImages[0].id
+        mockMvc.perform(
+            get("/stores/{storeId}/images?limit={limit}&offset={offset}", store.id, limit, offset)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.body.images").isEmpty)
+            .andExpect(jsonPath("$.body.last_image_id").value(null))
             .andDo(print())
     }
 

--- a/src/test/kotlin/com/sowez/photo/controller/StoreControllerTest.kt
+++ b/src/test/kotlin/com/sowez/photo/controller/StoreControllerTest.kt
@@ -3,12 +3,10 @@ package com.sowez.photo.controller
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.sowez.photo.dto.req.StoreCreateReqDto
 import com.sowez.photo.dto.req.StoreEditReqDto
-import com.sowez.photo.entity.Address
-import com.sowez.photo.entity.Brand
-import com.sowez.photo.entity.Image
-import com.sowez.photo.entity.Store
+import com.sowez.photo.entity.*
 import com.sowez.photo.repository.BrandRepository
 import com.sowez.photo.repository.ImageRepository
+import com.sowez.photo.repository.ReviewRepository
 import com.sowez.photo.repository.StoreRepository
 import com.sowez.photo.type.PayType
 import com.sowez.photo.type.StoreType
@@ -36,7 +34,8 @@ class StoreControllerTest(
     @Autowired val objectMapper: ObjectMapper,
     @Autowired val storeRepository: StoreRepository,
     @Autowired val brandRepository: BrandRepository,
-    @Autowired val imageRepository: ImageRepository
+    @Autowired val imageRepository: ImageRepository,
+    @Autowired val reviewRepository: ReviewRepository
 ) {
 
     @Test
@@ -296,19 +295,73 @@ class StoreControllerTest(
     @Test
     @DisplayName("매장 검색")
     fun search_store() {
+        // given
+        val image = imageRepository.save(
+            Image(
+                uuid = UUID.randomUUID().toString(),
+                originalName = "image.jpg",
+                name = "image",
+                extension = "jpg",
+                path = "/image"
+            )
+        )
+
+        val brand = brandRepository.save(
+            Brand(
+                logoImage = image,
+                name = "하루필름"
+            )
+        )
+
+        val store1 = storeRepository.save(
+            Store(
+                name = "하루필름 강남점",
+                type = StoreType.STORE,
+                addressInfo = Address(address = "여기저기"),
+                brand = brand,
+                operatingTime = "24시간 영업",
+                phoneNumber = "014-1234-5678",
+                payTypes = listOf(PayType.CARD, PayType.CASH)
+            )
+        )
+
+        val store2 = storeRepository.save(
+            Store(
+                name = "하루필름 강남2호점",
+                type = StoreType.STORE,
+                addressInfo = Address(address = "요기조기"),
+                brand = brand,
+                operatingTime = "24시간 영업",
+                phoneNumber = "011-1234-5678",
+                payTypes = listOf(PayType.CARD, PayType.SIMPLE)
+            )
+        )
+
+        storeRepository.save(
+            Store(
+                name = "하루필름 잠실점",
+                type = StoreType.STORE,
+                addressInfo = Address(address = "요기조기"),
+                brand = brand,
+                operatingTime = "24시간 영업",
+                phoneNumber = "011-1234-5678",
+                payTypes = listOf(PayType.CARD, PayType.SIMPLE)
+            )
+        )
+
         // when & then
         mockMvc.perform(
             get("/stores?q=강남")
         )
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.body.content[0].store_id").value(1))
+            .andExpect(jsonPath("$.body.content[0].store_id").value(store1.id))
             .andExpect(jsonPath("$.body.content[0].store_name").value("하루필름 강남점"))
             .andExpect(jsonPath("$.body.content[0].store_address").value("여기저기"))
-            .andExpect(jsonPath("$.body.content[0].review_cnt").value(101))
-            .andExpect(jsonPath("$.body.content[1].store_id").value(4))
+            .andExpect(jsonPath("$.body.content[0].review_cnt").isNumber)
+            .andExpect(jsonPath("$.body.content[1].store_id").value(store2.id))
             .andExpect(jsonPath("$.body.content[1].store_name").value("하루필름 강남2호점"))
             .andExpect(jsonPath("$.body.content[1].store_address").value("요기조기"))
-            .andExpect(jsonPath("$.body.content[1].review_cnt").value(79))
+            .andExpect(jsonPath("$.body.content[1].review_cnt").isNumber)
             .andDo(print())
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: test


### PR DESCRIPTION
### 작업 개요

- StoreServiceImpl 마저 구현 완료

### 작업 상세 내용

- 매장 검색 기능 구현
    - 현재는 `contains name`으로만 구현함
- 매장 사진 리스트 조회
- 관련 테스트 코드 수정
- 테스트 환경설정 추가 (메모리 DB 사용하도록 설정)


### 생각해볼 문제

- 매장 검색 시 리뷰수를 보여주기 위해 Store 엔티티에 일대다 매핑 필드 `reviews`를 추가함
    - 각 사진관별 리뷰 개수를 별도 조회하는 것보다 훨씬 효율적이라고 생각하여 추가하였음
    - 개수만 사용하고 리뷰에 직접 접근하지 못하도록 `private`으로 보호해 놓음
    - 추후 리뷰 리스트가 꼭 필요한 경우 `private`을 풀 수도 있으나, 웬만하면 리뷰는 리뷰레포에서 조회해서 사용해야 할듯
- 추후 검색 고도화 해야 함 (검색 조건 다양화)
- 매장 사진 리스트 불러올 때 JPQL을 썼는데, 나중에 QueryDsl로 더 단순화할 수도 있음