### PR TITLE
feat #31 - 브랜드, 부스, 배경색 서비스 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("org.postgresql:postgresql")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+    implementation(kotlin("stdlib"))
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/sowez/photo/controller/BoothBackgroundController.kt
+++ b/src/main/kotlin/com/sowez/photo/controller/BoothBackgroundController.kt
@@ -1,7 +1,6 @@
 package com.sowez.photo.controller
 
-import com.sowez.photo.dto.BoothBackgroundInfoResDto
-import com.sowez.photo.dto.BoothBackgroundsResDto
+import com.sowez.photo.dto.BoothBackgroundInfosResDto
 import com.sowez.photo.dto.res.*
 import com.sowez.photo.service.BoothBackgroundService
 import org.springframework.http.ResponseEntity
@@ -17,7 +16,7 @@ class BoothBackgroundController(
      */
     @GetMapping
     fun getBoothInfo(
-    ): ResponseEntity<ResponseDto<BoothBackgroundsResDto>>{
+    ): ResponseEntity<ResponseDto<BoothBackgroundInfosResDto>>{
         val boothBackgroundsResponse = boothBackgroundService.getBoothBackgroundInfo()
         return ResponseEntity.ok(ResponseDto(body = boothBackgroundsResponse))
     }

--- a/src/main/kotlin/com/sowez/photo/controller/BoothController.kt
+++ b/src/main/kotlin/com/sowez/photo/controller/BoothController.kt
@@ -19,12 +19,11 @@ class BoothController(
      */
     @PostMapping("/{storeId}/booth")
     fun createBooth(
+            @PathVariable storeId: Long,
             @RequestBody @Valid createDto: BoothCreateReqDto
-    ): ResponseEntity<ResponseDto<CreateResponseDto>> {
-        val newBootheId = boothService.createBooth(createDto)
-        return ResponseEntity.ok(
-                ResponseDto(body = CreateResponseDto(newBootheId))
-        )
+    ): ResponseEntity<ResponseDto<Void>> {
+        boothService.createBooth(storeId, createDto)
+        return ResponseEntity.ok(ResponseDto())
     }
 
     /**

--- a/src/main/kotlin/com/sowez/photo/controller/BrandController.kt
+++ b/src/main/kotlin/com/sowez/photo/controller/BrandController.kt
@@ -1,8 +1,7 @@
 package com.sowez.photo.controller
 
-import com.sowez.photo.dto.BoothInfoResDto
 import com.sowez.photo.dto.BrandInfoResDto
-import com.sowez.photo.dto.BrandsResponseDto
+import com.sowez.photo.dto.BrandInfosResDto
 import com.sowez.photo.dto.res.*
 import com.sowez.photo.service.BrandService
 import org.springframework.http.ResponseEntity
@@ -18,7 +17,7 @@ class BrandController(
      */
     @GetMapping
     fun getBoothInfo(
-    ): ResponseEntity<ResponseDto<BrandsResponseDto>>{
+    ): ResponseEntity<ResponseDto<BrandInfosResDto>>{
         val brandsResponse = brandService.getBrandInfo()
         return ResponseEntity.ok(ResponseDto(body = brandsResponse))
     }

--- a/src/main/kotlin/com/sowez/photo/dto/req/BoothBackgroundRequestDto.kt
+++ b/src/main/kotlin/com/sowez/photo/dto/req/BoothBackgroundRequestDto.kt
@@ -3,7 +3,6 @@ package com.sowez.photo.dto.req
 import com.sowez.photo.dto.SnakeCaseDto
 
 data class BoothBackgroundCreateReqDto(
-        val boothBackgroundColorId: Int,
         val boothBackgroundColorName: String,
         val boothBackgroundColorCode: String
 ) : SnakeCaseDto()

--- a/src/main/kotlin/com/sowez/photo/dto/req/BoothRequestDto.kt
+++ b/src/main/kotlin/com/sowez/photo/dto/req/BoothRequestDto.kt
@@ -1,32 +1,63 @@
 package com.sowez.photo.dto.req
 
 import com.sowez.photo.dto.SnakeCaseDto
+import com.sowez.photo.entity.BoothInfo
 import com.sowez.photo.type.DownloadType
 
 data class BoothCreateReqDto(
         val boothCount: Int,
-        val boothBackgroundColorName: List<String>,
-        val minPeopleCount: Int,
-        val maxPeopleCount: Int,
-        val downloadTypes: List<DownloadType>,
-        val downloadPeriod: String,
-        val isReshoot: Boolean,
-        val isRemote: Boolean,
-        val isCurlingIron: Boolean,
-        val isEnvelope: Boolean,
-        val isFootrest: Boolean
-) : SnakeCaseDto()
+        val boothBackgroundColorIds: List<Long>?,
+        val minPeopleCount: Int?,
+        val maxPeopleCount: Int?,
+        val downloadTypes: List<DownloadType>?,
+        val downloadPeriod: String?,
+        val isReshoot: Boolean?,
+        val isRemote: Boolean?,
+        val isCurlingIron: Boolean?,
+        val isEnvelope: Boolean?,
+        val isFootrest: Boolean?
+) : SnakeCaseDto() {
+    fun toEntity(): BoothInfo {
+        return BoothInfo(
+                boothCount = boothCount,
+                minPeopleCount = minPeopleCount,
+                maxPeopleCount = maxPeopleCount,
+                downloadTypes = downloadTypes?.joinToString(","), // List를 String으로 변환
+                downloadPeriod = downloadPeriod,
+                isReshoot = isReshoot,
+                isRemote = isRemote,
+                isCurlingIron = isCurlingIron,
+                isEnvelope = isEnvelope,
+                isFootrest = isFootrest
+        )
+    }
+}
 
 data class BoothEditReqDto(
-        val boothCount: Int,
-        val boothBackgroundColorName: List<String>,
-        val minPeopleCount: Int,
-        val maxPeopleCount: Int,
-        val downloadTypes: List<DownloadType>,
-        val downloadPeriod: String,
-        val isReshoot: Boolean,
-        val isRemote: Boolean,
-        val isCurlingIron: Boolean,
-        val isEnvelope: Boolean,
-        val isFootrest: Boolean
-) : SnakeCaseDto()
+        val boothCount: Int?,
+        val boothBackgroundColorIds: List<Long>?,
+        val minPeopleCount: Int?,
+        val maxPeopleCount: Int?,
+        val downloadTypes: List<DownloadType>?,
+        val downloadPeriod: String?,
+        val isReshoot: Boolean?,
+        val isRemote: Boolean?,
+        val isCurlingIron: Boolean?,
+        val isEnvelope: Boolean?,
+        val isFootrest: Boolean?
+) : SnakeCaseDto() {
+    fun toEntity(): BoothInfo {
+        return BoothInfo(
+                boothCount = boothCount,
+                minPeopleCount = minPeopleCount,
+                maxPeopleCount = maxPeopleCount,
+                downloadTypes = downloadTypes?.joinToString(","), // List를 String으로 변환
+                downloadPeriod = downloadPeriod,
+                isReshoot = isReshoot,
+                isRemote = isRemote,
+                isCurlingIron = isCurlingIron,
+                isEnvelope = isEnvelope,
+                isFootrest = isFootrest
+        )
+    }
+}

--- a/src/main/kotlin/com/sowez/photo/dto/res/BoothBackgroundResponseDto.kt
+++ b/src/main/kotlin/com/sowez/photo/dto/res/BoothBackgroundResponseDto.kt
@@ -1,11 +1,11 @@
 package com.sowez.photo.dto
 
-data class BoothBackgroundInfoResDto (
+data class BoothBackgroundInfoResDto(
         val boothBackgroundColorId: Long,
         val boothBackgroundColorName: String,
         val boothBackgroundColorCode: String
 ): SnakeCaseDto()
 
-data class BoothBackgroundsResDto (
+data class BoothBackgroundInfosResDto (
         val boothBackgroundColors: List<BoothBackgroundInfoResDto> = mutableListOf()
 ): SnakeCaseDto()

--- a/src/main/kotlin/com/sowez/photo/dto/res/BoothResponseDto.kt
+++ b/src/main/kotlin/com/sowez/photo/dto/res/BoothResponseDto.kt
@@ -3,15 +3,17 @@ package com.sowez.photo.dto
 import com.sowez.photo.type.DownloadType
 
 data class BoothInfoResDto (
-        val boothCount: Int,
-        val boothBackgroundColorName: List<String> = mutableListOf(),
-        val minPeopleCount: Int,
-        val maxPeopleCount: Int,
-        val downloadTypes: List<DownloadType> = mutableListOf(),
-        val downloadPeriod: String,
-        val isReshoot: Boolean,
-        val isRemote: Boolean,
-        val isCurlingIron: Boolean,
-        val isEnvelope: Boolean,
-        val isFootrest: Boolean,
+        val boothCount: Int?,
+        val boothBackgroundColorIds: List<Long>? = mutableListOf(),
+        val boothBackgroundColorNames: List<String>? = mutableListOf(),
+        val boothBackgroundColorCodes: List<String>? = mutableListOf(),
+        val minPeopleCount: Int?,
+        val maxPeopleCount: Int?,
+        val downloadTypes: List<DownloadType>? = mutableListOf(),
+        val downloadPeriod: String?,
+        val isReshoot: Boolean?,
+        val isRemote: Boolean?,
+        val isCurlingIron: Boolean?,
+        val isEnvelope: Boolean?,
+        val isFootrest: Boolean?,
 ): SnakeCaseDto()

--- a/src/main/kotlin/com/sowez/photo/dto/res/BrandResponseDto.kt
+++ b/src/main/kotlin/com/sowez/photo/dto/res/BrandResponseDto.kt
@@ -1,10 +1,13 @@
 package com.sowez.photo.dto
 
+import com.sowez.photo.entity.Image
+
 data class BrandInfoResDto (
         val brandId: Long,
+        val brandImageLogo : Image,
         val brandName: String
 ): SnakeCaseDto()
 
-data class BrandsResponseDto (
-    val brands: List<BrandInfoResDto> = mutableListOf()
+data class BrandInfosResDto(
+        val brands : List<BrandInfoResDto> = mutableListOf()
 ): SnakeCaseDto()

--- a/src/main/kotlin/com/sowez/photo/entity/BoothBackgroundColor.kt
+++ b/src/main/kotlin/com/sowez/photo/entity/BoothBackgroundColor.kt
@@ -4,8 +4,8 @@ import jakarta.persistence.*
 
 @Entity
 class BoothBackgroundColor(
-    name: String,
-    code: String
+        name: String,
+        code: String
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,6 +15,7 @@ class BoothBackgroundColor(
     @Column(nullable = false, name = "booth_background_color_name")
     var name: String = name
         protected set
+
     @Column(nullable = false, name = "booth_background_color_code")
     var code: String = code
         protected set

--- a/src/main/kotlin/com/sowez/photo/entity/Store.kt
+++ b/src/main/kotlin/com/sowez/photo/entity/Store.kt
@@ -8,12 +8,14 @@ import java.time.LocalDateTime
 
 @Entity
 class Store(
-    name: String, type: StoreType, brand: Brand,
-    addressInfo: Address,
-    phoneNumber: String? = null,
-    operatingTime: String? = null,
-    payTypes: List<PayType>? = null,
-    boothInfo: BoothInfo? = null
+        name: String,
+        type: StoreType,
+        brand: Brand,
+        addressInfo: Address,
+        phoneNumber: String? = null,
+        operatingTime: String? = null,
+        payTypes: List<PayType>? = null,
+        boothInfo: BoothInfo? = null
 ) {
 
     @Id
@@ -118,28 +120,23 @@ data class Address(
 
 @Embeddable
 data class BoothInfo(
-    @Column var boothCount: Int? = null,
-    @Column var minPeopleCount: Int? = null,
-    @Column var maxPeopleCount: Int? = null,
-    @Column var downloadPeriod: String? = null,
-    @Column var isReshoot: Boolean? = null,
-    @Column var isRemote: Boolean? = null,
-    @Column var isCurlingIron: Boolean? = null,
-    @Column var isEnvelope: Boolean? = null,
-    @Column var isFootrest: Boolean? = null
-) {
-    @Column var downloadTypes: String? = null
+        @Column var boothCount: Int? = null,
+        @Column var minPeopleCount: Int? = null,
+        @Column var maxPeopleCount: Int? = null,
+        @Column var downloadTypes: String? = null,
+        @Column var downloadPeriod: String? = null,
+        @Column var isReshoot: Boolean? = null,
+        @Column var isRemote: Boolean? = null,
+        @Column var isCurlingIron: Boolean? = null,
+        @Column var isEnvelope: Boolean? = null,
+        @Column var isFootrest: Boolean? = null
 
-    fun setDownloadTypes(downloadTypes: Set<DownloadType>?) {
-        this.downloadTypes = downloadTypes?.joinToString(",")
+) {
+    fun getDownloadTypes(): List<DownloadType>? {
+        return downloadTypes?.split(",")?.map { DownloadType.valueOf(it) }
     }
 
-    fun getDownloadTypes(): Set<DownloadType> {
-        val downloadTypeStrings: MutableSet<String> = mutableSetOf()
-        this.downloadTypes?.split(",")
-            ?.let { downloadTypeStrings.addAll(it) }
-        return downloadTypeStrings.map {
-            DownloadType.valueOf(it)
-        }.toSet()
+    fun setDownloadTypes(downloadTypes: List<DownloadType>?) {
+        this.downloadTypes = downloadTypes?.joinToString(",")
     }
 }

--- a/src/main/kotlin/com/sowez/photo/repository/StoreBoothBackgroundColorRepository.kt
+++ b/src/main/kotlin/com/sowez/photo/repository/StoreBoothBackgroundColorRepository.kt
@@ -1,9 +1,12 @@
 package com.sowez.photo.repository
 
+import com.sowez.photo.entity.Store
 import com.sowez.photo.entity.StoreBoothBackgroundColor
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface StoreBoothBackgroundColorRepository: JpaRepository<StoreBoothBackgroundColor, Long> {
+    fun findByStore(store: Store): List<StoreBoothBackgroundColor>?
+    fun deleteByStore(store: Store): List<StoreBoothBackgroundColor>?
 }

--- a/src/main/kotlin/com/sowez/photo/service/BoothBackgroundService.kt
+++ b/src/main/kotlin/com/sowez/photo/service/BoothBackgroundService.kt
@@ -1,25 +1,27 @@
 package com.sowez.photo.service
 
-import com.sowez.photo.dto.BoothBackgroundInfoResDto
-import com.sowez.photo.dto.BoothBackgroundsResDto
-import com.sowez.photo.dto.BrandInfoResDto
-import com.sowez.photo.dto.BrandsResponseDto
+import com.sowez.photo.dto.*
+import com.sowez.photo.repository.BoothBackgroundColorRepository
 import org.springframework.stereotype.Service
 
 @Service
 interface BoothBackgroundService {
-    fun getBoothBackgroundInfo(): BoothBackgroundsResDto
+    fun getBoothBackgroundInfo(): BoothBackgroundInfosResDto
 }
 
 @Service
-class BoothBackgroundServiceTestImpl : BoothBackgroundService {
-    override fun getBoothBackgroundInfo(): BoothBackgroundsResDto {
-        return BoothBackgroundsResDto(
-                listOf(
-                        BoothBackgroundInfoResDto(boothBackgroundColorId = 1, boothBackgroundColorName = "흰색", boothBackgroundColorCode ="#FFFFFF"),
-                        BoothBackgroundInfoResDto(boothBackgroundColorId = 2, boothBackgroundColorName = "하늘색", boothBackgroundColorCode ="#A1B1C1")
-                )
-        )
-    }
+class BoothBackgroundServiceImpl(
+        val boothBackgroundColorRepository: BoothBackgroundColorRepository
+) : BoothBackgroundService {
+    override fun getBoothBackgroundInfo(): BoothBackgroundInfosResDto {
+        val boothBackgroundColors = boothBackgroundColorRepository.findAll()
 
+        return BoothBackgroundInfosResDto(boothBackgroundColors.map { boothBackgroundColor ->
+            BoothBackgroundInfoResDto(
+                    boothBackgroundColorId = boothBackgroundColor.id,
+                    boothBackgroundColorName = boothBackgroundColor.name,
+                    boothBackgroundColorCode = boothBackgroundColor.code
+            )
+        })
+    }
 }

--- a/src/main/kotlin/com/sowez/photo/service/BoothService.kt
+++ b/src/main/kotlin/com/sowez/photo/service/BoothService.kt
@@ -3,43 +3,114 @@ package com.sowez.photo.service
 import com.sowez.photo.dto.BoothInfoResDto
 import com.sowez.photo.dto.req.BoothCreateReqDto
 import com.sowez.photo.dto.req.BoothEditReqDto
+import com.sowez.photo.entity.*
+import com.sowez.photo.error.StoreNotFoundException
+import com.sowez.photo.repository.*
 import com.sowez.photo.type.DownloadType
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 interface BoothService {
-    fun createBooth(createDto: BoothCreateReqDto): Long
+    fun createBooth(storeId: Long, createDto: BoothCreateReqDto)
     fun editBoothInfo(storeId: Long, editDto: BoothEditReqDto)
     fun getBoothInfo(storeId: Long): BoothInfoResDto
 }
 
 @Service
-class BoothServiceTestImpl : BoothService {
-    override fun createBooth(createDto: BoothCreateReqDto): Long {
+class BoothServiceImpl(
+        val storeRepository: StoreRepository,
+        val storeBoothBackgroundColorRepository: StoreBoothBackgroundColorRepository,
+        val boothBackgroundColorRepository: BoothBackgroundColorRepository,
+) : BoothService {
+    override fun createBooth(storeId: Long, createDto: BoothCreateReqDto) {
         println("BoothServiceTestImpl.createBooth")
-        return 1
+
+        // STORE 부스정보 등록
+        val store = storeRepository.findById(storeId)
+                .orElseThrow { StoreNotFoundException(storeId) }
+
+        store.addBoothInfo(
+                boothInfo = createDto.toEntity()
+        )
+
+        storeRepository.save(store)
+
+        // STORE_BOOTH_BACKGROUND_COLOR 등록
+        createDto.boothBackgroundColorIds?.let { ids ->
+            val backgroundColors = boothBackgroundColorRepository.findAllById(ids)
+
+            backgroundColors.map { color ->
+                StoreBoothBackgroundColor(
+                        store = store,
+                        boothBackgroundColor = color
+                )
+            }.let { storeBoothBackgroundColors ->
+                storeBoothBackgroundColorRepository.saveAll(storeBoothBackgroundColors)
+            }
+        }
     }
 
+    @Transactional
     override fun editBoothInfo(storeId: Long, editDto: BoothEditReqDto) {
         println("BoothServiceTestImpl.editBoothInfo")
+
+        // STORE 부스정보 업데이트
+        val store = storeRepository.findById(storeId)
+                .orElseThrow { StoreNotFoundException(storeId) }
+
+        store.addBoothInfo(
+                boothInfo = editDto.toEntity()
+        )
+
+        storeRepository.save(store)
+
+        // boothBackgroundColor 삭제 후 재생성
+        storeBoothBackgroundColorRepository.deleteByStore(store)
+
+        editDto.boothBackgroundColorIds?.let { ids ->
+            val backgroundColors = boothBackgroundColorRepository.findAllById(ids)
+
+            backgroundColors.map { color ->
+                StoreBoothBackgroundColor(
+                        store = store,
+                        boothBackgroundColor = color
+                )
+            }.let { storeBoothBackgroundColors ->
+                storeBoothBackgroundColorRepository.saveAll(storeBoothBackgroundColors)
+            }
+        }
+
         return
     }
 
     override fun getBoothInfo(storeId: Long): BoothInfoResDto {
         println("BoothServiceTestImpl.getBoothInfo")
-        return BoothInfoResDto(
-                boothCount = 3,
-                boothBackgroundColorName = listOf("분홍", "파랑", "회색"),
-                minPeopleCount = 1,
-                maxPeopleCount = 6,
-                downloadTypes = listOf(DownloadType.QR, DownloadType.APP),
-                downloadPeriod = "7",
-                isReshoot = true,
-                isRemote = true,
-                isCurlingIron = true,
-                isEnvelope = true,
-                isFootrest = true
-        )
+
+        val store = storeRepository.findById(storeId)
+                .orElseThrow { StoreNotFoundException(storeId) }
+
+        // StoreBoothBackgroundColors 조회
+        val storeBoothBackgroundColors = storeBoothBackgroundColorRepository.findByStore(store)
+
+        return store
+                .run {
+                    BoothInfoResDto(
+                            boothCount = this.boothInfo?.boothCount,
+                            boothBackgroundColorIds = storeBoothBackgroundColors?.map { it.boothBackgroundColor.id },
+                            boothBackgroundColorNames = storeBoothBackgroundColors?.map { it.boothBackgroundColor.name },
+                            boothBackgroundColorCodes = storeBoothBackgroundColors?.map { it.boothBackgroundColor.code },
+                            minPeopleCount = this.boothInfo?.minPeopleCount,
+                            maxPeopleCount = this.boothInfo?.maxPeopleCount,
+                            downloadTypes = this.boothInfo?.getDownloadTypes(),
+                            downloadPeriod = this.boothInfo?.downloadPeriod,
+                            isReshoot = this.boothInfo?.isReshoot,
+                            isRemote = this.boothInfo?.isRemote,
+                            isCurlingIron = this.boothInfo?.isCurlingIron,
+                            isEnvelope = this.boothInfo?.isEnvelope,
+                            isFootrest = this.boothInfo?.isFootrest
+                    )
+                }
     }
 
 

--- a/src/main/kotlin/com/sowez/photo/service/BrandService.kt
+++ b/src/main/kotlin/com/sowez/photo/service/BrandService.kt
@@ -1,24 +1,27 @@
 package com.sowez.photo.service
 
-import com.sowez.photo.dto.BoothBackgroundInfoResDto
 import com.sowez.photo.dto.BrandInfoResDto
-import com.sowez.photo.dto.BrandsResponseDto
+import com.sowez.photo.dto.BrandInfosResDto
+import com.sowez.photo.repository.BrandRepository
 import org.springframework.stereotype.Service
 
 @Service
 interface BrandService {
-    fun getBrandInfo(): BrandsResponseDto
+    fun getBrandInfo(): BrandInfosResDto
 }
 
 @Service
-class BrandServiceTestImpl : BrandService {
-    override fun getBrandInfo(): BrandsResponseDto {
-        return BrandsResponseDto(
-                listOf(
-                        BrandInfoResDto(brandId = 1, brandName = "하루필름"),
-                        BrandInfoResDto(brandId = 2, brandName = "인생네컷")
-                )
-        )
+class BrandServiceImpl(
+        val brandRepository: BrandRepository
+) : BrandService {
+    override fun getBrandInfo(): BrandInfosResDto {
+        val brands = brandRepository.findAll()
+        return BrandInfosResDto(brands.map { brand ->
+            BrandInfoResDto(
+                    brandId = brand.id,
+                    brandName = brand.name,
+                    brandImageLogo = brand.logoImage
+            )
+        })
     }
-
 }

--- a/src/test/kotlin/com/sowez/photo/controller/BoothBackgroundControllerTest.kt
+++ b/src/test/kotlin/com/sowez/photo/controller/BoothBackgroundControllerTest.kt
@@ -1,6 +1,8 @@
 package com.sowez.photo.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.sowez.photo.entity.BoothBackgroundColor
+import com.sowez.photo.repository.BoothBackgroundColorRepository
 import org.junit.jupiter.api.Test
 
 import org.junit.jupiter.api.Assertions.*
@@ -11,26 +13,41 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.transaction.annotation.Transactional
 
 
 @AutoConfigureMockMvc
 @SpringBootTest
+@Transactional
 internal class BoothBackgroundControllerTest(
         @Autowired val mockMvc: MockMvc,
-        @Autowired val objectMapper: ObjectMapper
+        @Autowired val objectMapper: ObjectMapper,
+        @Autowired val boothBackgroundColorRepository: BoothBackgroundColorRepository
 ) {
 
     @Test
-    fun getBoothInfo() {
+    fun getBoothBackgroundInfo() {
 
+        val boothBackgroundColor = boothBackgroundColorRepository.save(
+                BoothBackgroundColor(
+                        name = "흰색",
+                        code = "#FFFFFF"
+                )
+        )
+        val boothBackgroundColor2 = boothBackgroundColorRepository.save(
+                BoothBackgroundColor(
+                        name = "하늘색",
+                        code = "#A1B1C1"
+                )
+        )
         mockMvc.perform(
                 MockMvcRequestBuilders.get("/backgrounds")
         )
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_colors[0].booth_background_color_id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_colors[0].booth_background_color_id").value(boothBackgroundColor.id))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_colors[0].booth_background_color_name").value("흰색"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_colors[0].booth_background_color_code").value("#FFFFFF"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_colors[1].booth_background_color_id").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_colors[1].booth_background_color_id").value(boothBackgroundColor2.id))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_colors[1].booth_background_color_name").value("하늘색"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_colors[1].booth_background_color_code").value("#A1B1C1"))
 

--- a/src/test/kotlin/com/sowez/photo/controller/BoothControllerTest.kt
+++ b/src/test/kotlin/com/sowez/photo/controller/BoothControllerTest.kt
@@ -3,7 +3,12 @@ package com.sowez.photo.controller
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.sowez.photo.dto.req.BoothCreateReqDto
 import com.sowez.photo.dto.req.BoothEditReqDto
+import com.sowez.photo.entity.*
+import com.sowez.photo.repository.*
 import com.sowez.photo.type.DownloadType
+import com.sowez.photo.type.PayType
+import com.sowez.photo.type.StoreType
+import org.hibernate.internal.util.collections.CollectionHelper.listOf
 import org.junit.jupiter.api.Test
 
 import org.junit.jupiter.api.Assertions.*
@@ -16,47 +21,61 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
 
 @AutoConfigureMockMvc
 @SpringBootTest
+@Transactional
 internal class BoothControllerTest(
         @Autowired val mockMvc: MockMvc,
-        @Autowired val objectMapper: ObjectMapper
+        @Autowired val objectMapper: ObjectMapper,
+        @Autowired val imageRepository: ImageRepository,
+        @Autowired val brandRepository: BrandRepository,
+        @Autowired val storeRepository: StoreRepository,
+        @Autowired val boothBackgroundColorRepository: BoothBackgroundColorRepository,
+        @Autowired val storeBoothBackgroundColorRepository: StoreBoothBackgroundColorRepository
+
+
 ) {
 
     @Test
     @DisplayName("부스 생성")
     fun createBooth() {
+        // given
+        val image = imageRepository.save(
+                Image(
+                        uuid = UUID.randomUUID().toString(),
+                        originalName = "image.jpg",
+                        name = "image",
+                        extension = "jpg",
+                        path = "/image"
+                )
+        )
+
+        val brand = brandRepository.save(
+                Brand(
+                        logoImage = image,
+                        name = "하루필름"
+                )
+        )
+
+        val store = storeRepository.save(
+                Store(
+                        name = "하루필름 강남점",
+                        type = StoreType.STORE,
+                        addressInfo = Address(address = "서울 어쩌구 저쩌구"),
+                        brand = brand,
+                        operatingTime = "24시간 영업",
+                        phoneNumber = "010-1234-5678",
+                        payTypes = listOf(PayType.CARD, PayType.CASH)
+                )
+        )
+
+
         val booth = BoothCreateReqDto(
-            boothCount = 3,
-            boothBackgroundColorName = listOf("분홍", "파랑", "회색"),
-            minPeopleCount = 1,
-            maxPeopleCount = 6,
-            downloadTypes = listOf(DownloadType.QR, DownloadType.APP),
-            downloadPeriod = "7",
-            isReshoot = true,
-            isRemote = true,
-            isCurlingIron = true,
-            isEnvelope = true,
-            isFootrest = true
-        )
-
-        mockMvc.perform(
-                MockMvcRequestBuilders.post("/stores/{storeId}/booth",1)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(booth))
-        )
-                .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.body.created").value(1L))
-                .andDo(MockMvcResultHandlers.print())
-    }
-
-    @Test
-    @DisplayName("부스 수정")
-    fun editBoothInfo() {
-        val booth = BoothEditReqDto(
-                boothCount = 4,
-                boothBackgroundColorName = listOf("분홍", "파랑", "회색", "흰색"),
+                boothCount = 3,
+                boothBackgroundColorIds = listOf(1, 2, 3),
                 minPeopleCount = 1,
                 maxPeopleCount = 6,
                 downloadTypes = listOf(DownloadType.QR, DownloadType.APP),
@@ -69,7 +88,62 @@ internal class BoothControllerTest(
         )
 
         mockMvc.perform(
-                MockMvcRequestBuilders.patch("/stores/{storeId}/booth",1)
+                MockMvcRequestBuilders.post("/stores/{storeId}/booth", store.id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(booth))
+        )
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andDo(MockMvcResultHandlers.print())
+    }
+
+    @Test
+    @DisplayName("부스 수정")
+    fun editBoothInfo() {
+        val image = imageRepository.save(
+                Image(
+                        uuid = UUID.randomUUID().toString(),
+                        originalName = "image.jpg",
+                        name = "image",
+                        extension = "jpg",
+                        path = "/image"
+                )
+        )
+
+        val brand = brandRepository.save(
+                Brand(
+                        logoImage = image,
+                        name = "하루필름"
+                )
+        )
+
+        val store = storeRepository.save(
+                Store(
+                        name = "하루필름 강남점",
+                        type = StoreType.STORE,
+                        addressInfo = Address(address = "서울 어쩌구 저쩌구"),
+                        brand = brand,
+                        operatingTime = "24시간 영업",
+                        phoneNumber = "010-1234-5678",
+                        payTypes = listOf(PayType.CARD, PayType.CASH),
+                )
+        )
+
+        val booth = BoothEditReqDto(
+                boothCount = 4,
+                boothBackgroundColorIds = listOf(1, 2, 3),
+                minPeopleCount = 1,
+                maxPeopleCount = 6,
+                downloadTypes = listOf(DownloadType.QR, DownloadType.APP),
+                downloadPeriod = "7",
+                isReshoot = true,
+                isRemote = true,
+                isCurlingIron = true,
+                isEnvelope = true,
+                isFootrest = true
+        )
+
+        mockMvc.perform(
+                MockMvcRequestBuilders.patch("/stores/{storeId}/booth", store.id)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(booth))
         )
@@ -80,14 +154,86 @@ internal class BoothControllerTest(
     @Test
     @DisplayName("부스 정보 조회")
     fun getBoothInfo() {
+        val image = imageRepository.save(
+                Image(
+                        uuid = UUID.randomUUID().toString(),
+                        originalName = "image.jpg",
+                        name = "image",
+                        extension = "jpg",
+                        path = "/image"
+                )
+        )
+
+        val brand = brandRepository.save(
+                Brand(
+                        logoImage = image,
+                        name = "하루필름"
+                )
+        )
+
+        val boothInfo = BoothInfo(
+                boothCount = 3,
+                minPeopleCount = 1,
+                maxPeopleCount = 6,
+                downloadPeriod = "7",
+                isReshoot = true,
+                isRemote = true,
+                isCurlingIron = true,
+                isEnvelope = true,
+                isFootrest = true
+        )
+
+        boothInfo.setDownloadTypes(listOf(DownloadType.QR, DownloadType.APP))
+
+        val store = storeRepository.save(
+                Store(
+                        name = "하루필름 강남점",
+                        type = StoreType.STORE,
+                        addressInfo = Address(address = "서울 어쩌구 저쩌구"),
+                        brand = brand,
+                        operatingTime = "24시간 영업",
+                        phoneNumber = "010-1234-5678",
+                        payTypes = listOf(PayType.CARD, PayType.CASH),
+                        boothInfo = boothInfo
+                )
+        )
+
+        val boothBackgroundColor = boothBackgroundColorRepository.save(
+                BoothBackgroundColor(
+                        name = "분홍",
+                        code = "#ffffff"
+                )
+        )
+
+        val storeBoothBackgroundColor = storeBoothBackgroundColorRepository.save(
+                StoreBoothBackgroundColor(
+                        store = store,
+                        boothBackgroundColor = boothBackgroundColor
+                )
+        )
+
+        val boothBackgroundColor2 = boothBackgroundColorRepository.save(
+                BoothBackgroundColor(
+                        name = "파랑",
+                        code = "#ffffff"
+                )
+        )
+
+        val storeBoothBackgroundColor2 = storeBoothBackgroundColorRepository.save(
+                StoreBoothBackgroundColor(
+                        store = store,
+                        boothBackgroundColor = boothBackgroundColor2
+                )
+        )
+
+
         mockMvc.perform(
-                MockMvcRequestBuilders.get("/stores/{storeId}/booth",1)
+                MockMvcRequestBuilders.get("/stores/{storeId}/booth", store.id)
         )
                 .andExpect(MockMvcResultMatchers.status().isOk)
                 .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_count").value(3))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_color_name[0]").value("분홍"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_color_name[1]").value("파랑"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_color_name[2]").value("회색"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_color_names[0]").value("분홍"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.body.booth_background_color_names[1]").value("파랑"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.body.min_people_count").value(1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.body.max_people_count").value(6))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.body.download_types[0]").value(DownloadType.QR.name))

--- a/src/test/kotlin/com/sowez/photo/controller/BrandControllerTest.kt
+++ b/src/test/kotlin/com/sowez/photo/controller/BrandControllerTest.kt
@@ -1,6 +1,10 @@
 package com.sowez.photo.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.sowez.photo.entity.Brand
+import com.sowez.photo.entity.Image
+import com.sowez.photo.repository.BrandRepository
+import com.sowez.photo.repository.ImageRepository
 import org.junit.jupiter.api.Test
 
 import org.junit.jupiter.api.Assertions.*
@@ -11,23 +15,63 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
 
 @AutoConfigureMockMvc
 @SpringBootTest
+@Transactional
 internal class BrandControllerTest(
         @Autowired val mockMvc: MockMvc,
-        @Autowired val objectMapper: ObjectMapper
+        @Autowired val objectMapper: ObjectMapper,
+        @Autowired val imageRepository: ImageRepository,
+        @Autowired val brandRepository: BrandRepository
 ) {
 
     @Test
-    fun getBoothInfo() {
+    fun getBrandInfo() {
+
+        val image = imageRepository.save(
+                Image(
+                        uuid = UUID.randomUUID().toString(),
+                        originalName = "image.jpg",
+                        name = "image",
+                        extension = "jpg",
+                        path = "/image"
+                )
+        )
+
+        val brand = brandRepository.save(
+                Brand(
+                        logoImage = image,
+                        name = "하루필름"
+                )
+        )
+
+        val image2 = imageRepository.save(
+                Image(
+                        uuid = UUID.randomUUID().toString(),
+                        originalName = "image.jpg",
+                        name = "image",
+                        extension = "jpg",
+                        path = "/image"
+                )
+        )
+
+        val brand2 = brandRepository.save(
+                Brand(
+                        logoImage = image2,
+                        name = "인생네컷"
+                )
+        )
+
         mockMvc.perform(
                 MockMvcRequestBuilders.get("/brands")
         )
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.body.brands[0].brand_id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.body.brands[0].brand_id").value(brand.id))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.body.brands[0].brand_name").value("하루필름"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.body.brands[1].brand_id").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.body.brands[1].brand_id").value(brand2.id))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.body.brands[1].brand_name").value("인생네컷"))
                 .andDo(MockMvcResultHandlers.print())
 


### PR DESCRIPTION
### 작업 개요
- BoothController, BoothBackGroundController, BrandController 테스트 코드 작성
- 테스트 중 발생한 오류 해결

### 작업 상세 내용
- 테스트용 BoothService, BoothBackGroundService, BrandService 로직 구현
- BoothController, BoothBackGroundController, BrandController 관련 API 테스트 코드 작성
- BoothBackGroundController, BrandController List 클래스 추가

### 생각해볼 문제
- Transactional : EditBoothInfo에서 deleteByStore시에 remove call 에러
