### PR TITLE
Feat/#37 - API 호출 로깅 기능 추가 (콘솔만)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,11 @@ configurations {
 	compileOnly {
 		extendsFrom(configurations.annotationProcessor.get())
 	}
+
+	all {
+		// 기존 스프링부트에 있는 로거(Logback) 의존성을 제외한다. -> LOG4J2 를 쓰기 위해
+		exclude(group="org.springframework.boot", module="spring-boot-starter-logging")
+	}
 }
 
 repositories {
@@ -26,6 +31,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-log4j2")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	runtimeOnly("com.h2database:h2")

--- a/src/main/kotlin/com/sowez/photo/config/LogConfig.kt
+++ b/src/main/kotlin/com/sowez/photo/config/LogConfig.kt
@@ -1,0 +1,65 @@
+package com.sowez.photo.config
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+
+inline fun <reified T> T.logger() = LoggerFactory.getLogger(T::class.java)!!
+
+@Component
+class LogInterceptor: HandlerInterceptor {
+
+    val log = logger()
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        log.info("[REQUEST] {} {}", request.method, request.requestURI)
+        return true
+    }
+
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?
+    ) {
+        log.info("[RESPONSE] {} {}\n\n", request.method, request.requestURI)
+    }
+}
+
+@Component
+@Aspect
+class LogAspect {
+
+    val log = logger()
+    val MAX_LOG_LENGTH = 1000
+
+    @Around("execution(* com.sowez.photo.controller.*Controller.*(..))")
+    @Throws(Throwable::class)
+    fun controllerLogging(jp: ProceedingJoinPoint): Any {
+        log.info("* 메서드 " + jp.signature.name + " 시작")
+        val parameters = getSubString(jp.args.contentToString())
+        log.info("* 파라미터: $parameters")
+
+        val result = jp.proceed()
+
+        log.info("* 메서드 " + jp.signature.name + " 종료")
+        val resultStr = getSubString(result.toString())
+        log.info("* 결과: $resultStr")
+
+        return result
+    }
+
+    private fun getSubString(str: String): String {
+        return if (str.length <= MAX_LOG_LENGTH) {
+            str
+        } else {
+            str.substring(MAX_LOG_LENGTH).plus("...")
+        }
+    }
+}

--- a/src/main/kotlin/com/sowez/photo/config/WebConfig.kt
+++ b/src/main/kotlin/com/sowez/photo/config/WebConfig.kt
@@ -1,0 +1,20 @@
+package com.sowez.photo.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig(
+    val logInterceptor: LogInterceptor
+): WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOrigins("*")
+    }
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(logInterceptor)
+    }
+}

--- a/src/main/kotlin/com/sowez/photo/dto/res/ResponseDto.kt
+++ b/src/main/kotlin/com/sowez/photo/dto/res/ResponseDto.kt
@@ -3,8 +3,8 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.sowez.photo.error.ErrorCode
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-class ResponseDto<T>(
-    errorCode: ErrorCode = ErrorCode.SUCCESS,
+data class ResponseDto<T>(
+    val errorCode: ErrorCode = ErrorCode.SUCCESS,
     val body: T? = null
 ) {
     val status: Int = errorCode.code


### PR DESCRIPTION
### 작업 개요
- API 호출 시 콘솔에 로그가 찍히도록 로깅 기능 추가

### 작업 상세 내용
- log4j 라이브러리 추가
- API 호출 및 응답 시 콘솔 로그가 찍히도록 인터셉터 구현
- 컨트롤러 메소드 실행 시 파라미터 정보를 출력하는 애스팩트 구현

### 생각해볼 문제
- 배포 후에는 로그가 파일로 저장되도록 설정 필요